### PR TITLE
feat(api): added the startup script for automatic mount of the bucket

### DIFF
--- a/apps/github-interactions-api/src/app/app.controller.ts
+++ b/apps/github-interactions-api/src/app/app.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 
 import { AppService } from './app.service';
+import { STATUS_CODES } from 'http';
 
 
 @Controller()
@@ -9,8 +10,9 @@ export class AppController {
   
 
   @Get('/latest-linux-artifact')
-  getArtifact() {
-    this.appService.getArtifact();
+  async getArtifact() {
+    await this.appService.getArtifact();
+    return "OK";
   }
 
   @Get()

--- a/apps/github-interactions-api/src/app/app.service.ts
+++ b/apps/github-interactions-api/src/app/app.service.ts
@@ -44,11 +44,11 @@ export class AppService {
     );
 
     return createAppAuth({
-      id: AppConfig.GITHUB_APP_ID,
+      id: AppConfig.GITHUB_APP_ID as number,
       privateKey: secret,
-      installationId: AppConfig.GITHUB_APP_INSTALLATION_ID,
-      clientId: AppConfig.GITHUB_APP_CLIENT_ID,
-      clientSecret: AppConfig.GITHUB_APP_CLIENT_SECRET,
+      installationId: AppConfig.GITHUB_APP_INSTALLATION_ID as number,
+      clientId: AppConfig.GITHUB_APP_CLIENT_ID as string,
+      clientSecret: AppConfig.GITHUB_APP_CLIENT_SECRET as string,
     });
 
   }

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,11 @@
+export enum AppConfig {
+    GCP_API_KEY = "xxx",
+    NAME_OF_GITHUB_APP_PRIVATE_KEY = "xxxx.private-key.pem",
+    GITHUB_APP_ID = 77777,
+    GITHUB_APP_INSTALLATION_ID = 7777,
+    GITHUB_APP_CLIENT_ID = "Iv1.xxxxx",
+    GITHUB_APP_CLIENT_SECRET = "xxxx",
+    PATH_TO_GCP_CREDENTIALS = "/path/to/credentials.json",
+    PATH_TO_EXECUTABLE_SCRIPT = "/path/to/script.sh"
+}
+  

--- a/libs/api-implementation/orchestration/src/lib/orchestration.module.ts
+++ b/libs/api-implementation/orchestration/src/lib/orchestration.module.ts
@@ -9,4 +9,5 @@ import { Compute } from './compute.service';
   controllers: [VMOrchestrationController],
   providers: [VMOrchestrationService, Compute],
 })
+  
 export class VMOrchestrationModule { }

--- a/libs/api-implementation/orchestration/src/lib/orchestration.service.ts
+++ b/libs/api-implementation/orchestration/src/lib/orchestration.service.ts
@@ -1,108 +1,138 @@
 // TODO: parse errors properly
 // TODO: encapsulate the logic inside of methods
-import { VMOrchestrationInterface } from "./interfaces/vm-orchestration-interface";
-import { VMInterface } from "../../../util/src/lib/interfaces/vm-interface";
-import { Compute}  from "./compute.service";
-import { Injectable } from "@nestjs/common";
-import { HashTable } from "../../../util/src/lib/interfaces/hashtable-interface";
-import { VM } from "../../../util/src/lib/vm.impl";
-import { Status } from "../../../util/src/lib/interfaces/status-enum";
+import { VMOrchestrationInterface } from './interfaces/vm-orchestration-interface';
+import { VMInterface } from '../../../util/src/lib/interfaces/vm-interface';
+import { Compute } from './compute.service';
+import { Injectable } from '@nestjs/common';
+import { HashTable } from '../../../util/src/lib/interfaces/hashtable-interface';
+import { VM } from '../../../util/src/lib/vm.impl';
+import { Status } from '../../../util/src/lib/interfaces/status-enum';
+import { AppConfig } from '../../../../../config';
+import * as fs from 'fs';
+import * as doAsync from 'doasync';
+import * as path from 'path';
+import { execSync, exec } from 'child_process'
 
 @Injectable()
 export class VMOrchestrationService implements VMOrchestrationInterface {
+  private compute;
+  private machines: HashTable<VM>;
+  private runningMachines: VM[];
+  private numOfTotalInstances: number;
+  private zone;
+
+  constructor(compute: Compute) {
+    this.compute = compute;
+    this.zone = this.compute.zone('us-central1-c');
+    this.numOfTotalInstances = 0;
+    this.runningMachines = [];
+    this.machines = {};
+  }
+
+  async createMachine(name: string) {
+    try {
+      const [vm, operation] = await this.createVM(name);
+      this.runningMachines.push(vm);
+      this.numOfTotalInstances++;
+      console.log('Created the following machine: \n' + operation.metadata);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  public async createVM(name: string) {
+    let vm, operation;
+    const config = await this.getConfigFile();
+    [vm, operation] = await this.zone.createVM(name, config);
+    this.machines[name] = new VM(name, Status.Running, vm);
+    return [this.machines[name], operation];
+  }
+
+  private async getConfigFile() {
     
-    private compute;
-    private machines: HashTable<VM>;
-    private runningMachines: VM[];
-    private numOfTotalInstances: number;
-    private zone;
+    const script = await doAsync(fs).readFile(
+      path.resolve(__dirname, `../../../script.sh`)
+    );
 
-    constructor(compute: Compute) {
-        this.compute = compute;
-        this.zone = this.compute.zone('us-central1-c');
-        this.numOfTotalInstances = 0;
-        this.runningMachines = [];
-        this.machines = {};
-    }
+    console.log(script.toString());
 
-    async createMachine(name: string) {
-        try {
-            const [vm, operation] = await this.createVM(name);
-            this.runningMachines.push(vm);
-            this.numOfTotalInstances++;
-            console.log("Created the following machine: \n" + operation.metadata)
-        } catch (error) {
-            throw (error);
-        }
-    }
-    
-    public async createVM(name: string) {
-        let vm, operation;
-        [vm, operation] = await this.zone.createVM(name, { os: 'ubuntu' });
-        this.machines[name] = new VM(name, Status.Running, vm);
-        return [this.machines[name], operation]    
-    }
+    return {
+      os: 'ubuntu',
+      http: true,
+      metadata: {
+        items: [
+          {
+            key: 'startup-script',
+            value: script.toString(),
+          },
+        ],
+      },
+    };
+  }
 
-    async reset(name: string) {
-        try {
-            const response = await this.machines[name].getInstance().reset();
-            console.log(response);
-        } catch (error) {
-            throw (error);
-        }
+  async reset(name: string) {
+    try {
+      const response = await this.machines[name].getInstance().reset();
+      console.log(response);
+    } catch (error) {
+      throw error;
     }
+  }
 
-    async start(name: string) {
-        try {
-            const response = await this.machines[name].getInstance().start();
-            this.runningMachines.push(this.machines[name]);
-            console.log(response);
-        } catch (error) {
-            throw (error);
-        }
+  async start(name: string) {
+    try {
+      const response = await this.machines[name].getInstance().start();
+      this.runningMachines.push(this.machines[name]);
+      console.log(response);
+    } catch (error) {
+      throw error;
     }
-    async stop(name: string) {
-        try {
-            const response = await this.machines[name].getInstance().stop();
-            const index = this.runningMachines.indexOf(this.machines[name].getInstance());
-            if (index > -1) {
-                this.runningMachines.splice(index, 1);
-            }
-            console.log(response);
-        } catch (error) {
-            throw (error);
-        }
+  }
+  async stop(name: string) {
+    try {
+      const response = await this.machines[name].getInstance().stop();
+      const index = this.runningMachines.indexOf(
+        this.machines[name].getInstance()
+      );
+      if (index > -1) {
+        this.runningMachines.splice(index, 1);
+      }
+      console.log(response);
+    } catch (error) {
+      throw error;
     }
-    async deleteMachine(name: string) {
-        try {
-            if (this.machines[name].getStatus() == Status.Running) {
-                const index = this.runningMachines.indexOf(this.machines[name].getInstance());
-                this.runningMachines.splice(index, 1);
-            }
-            this.numOfTotalInstances--;
-            const response = await this.machines[name].getInstance().delete();
-            console.log(response);
-        } catch (error) {
-            throw (error);
-        }
+  }
+  async deleteMachine(name: string) {
+    try {
+      if (this.machines[name].getStatus() == Status.Running) {
+        const index = this.runningMachines.indexOf(
+          this.machines[name].getInstance()
+        );
+        this.runningMachines.splice(index, 1);
+      }
+      this.numOfTotalInstances--;
+      const response = await this.machines[name].getInstance().delete();
+      console.log(response);
+    } catch (error) {
+      throw error;
     }
-    getNumberOfRunningInstances(): number {
-        return this.runningMachines.length;
+  }
+  getNumberOfRunningInstances(): number {
+    return this.runningMachines.length;
+  }
+  getNumberOfTotalInstances(): number {
+    return this.numOfTotalInstances;
+  }
+  getRunningInstances(): VMInterface[] {
+    return this.runningMachines;
+  }
+  getAllInstances(): VMInterface[] {
+    const allInstances = [];
+    for (const key in this.machines) {
+      if (this.machines.hasOwnProperty(key)) {
+        allInstances.push(this.machines[key]);
+      }
     }
-    getNumberOfTotalInstances(): number {
-        return this.numOfTotalInstances;
-    }
-    getRunningInstances(): VMInterface[] {
-        return this.runningMachines;
-    }
-    getAllInstances(): VMInterface[] {
-        const allInstances = [];
-        for (const key in this.machines) {
-            if (this.machines.hasOwnProperty(key)) {
-                allInstances.push(this.machines[key]);
-            }
-        }
-        return allInstances;
-    }
-    
+    return allInstances;
+  }
 }

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# gce project metadata key where the config json is stored as a string
+meta_key=g-credentials
+env_key=GOOGLE_APPLICATION_CREDENTIALS
+config_file=/opt/g-credentials.json
+env_file=/etc/profile
+
+# command to set env variable
+temp_cmd="export $env_key=$config_file"
+
+# command to write $temp_cmd to file if $temp_cmd doesnt exist w/in it
+perm_cmd="grep -q -F '$temp_cmd' $env_file || echo '$temp_cmd' >> $env_file"
+
+# set the env var for only for the duration of this script.
+# can delete this if you don't start processes at the end of
+# this script that utilize the env var.
+eval $temp_cmd
+
+# set the env var permanently for any SUBSEQUENT shell logins
+eval $perm_cmd
+
+# load the config from the projects metadata
+config=`curl -f http://metadata.google.internal/computeMetadata/v1/project/attributes/$meta_key -H "Metadata-Flavor: Google" 2>/dev/null`
+
+# write it to file
+echo $config > $config_file
+
+
+cd ~
+
+echo "deb http://packages.cloud.google.com/apt gcsfuse-bionic main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+
+sudo apt-get update && sudo apt-get install fuse
+sudo groupadd fuse
+sudo adduser $USER fuse
+sudo chmod g+rw /dev/fuse
+sudo chgrp fuse /dev/fuse
+
+sudo apt-get install gcsfuse
+sudo usermod -a -G fuse $USER
+
+mkdir bucket
+GOOGLE_APPLICATION_CREDENTIALS=/opt/g-credentials.json gcsfuse ccextractor-samples bucket
+
+


### PR DESCRIPTION
**Problem:**

There was a problem with the credentials on the child VM instances. In order to mount the bucket, it needs the credentials.json file, but I can't transfer it through the bucket. Chicken and egg problem. I have spent a lot of time, trying different approaches, but now It finally works! The solution was not straightforward: I have uploaded the credentials.json to the project's metadata. And wrote the script with the comments to properly read it. Hope it is self-explanatory.

**Key feature**
Right now, after the merge of this PR, the process as follows:
   
1. Someone commits/PR to the ccextractor
2. After successful compilation, the GA on ccextractor pings the endpoint on system in order to automatically download the artifact
3. The system will remove the previous artifact from the bucket (if it is there), and upload the new one. (this step is absent since now the role of orchestration machine belongs to my local machine).
4. GA will ping another endpoint for the automatic creation of the VM machine
5. New child VM will be created, it executes the startup script, and mounts the bucket. That means now it has access to the compiled ccextractor and samples!
6. Test against samples (Now this step is absent, and it will be my next focus).