### PR TITLE
Automated test runs

### DIFF
--- a/libs/api-implementation/orchestration/src/lib/orchestration.controller.ts
+++ b/libs/api-implementation/orchestration/src/lib/orchestration.controller.ts
@@ -8,7 +8,11 @@ export class VMOrchestrationController {
 
   @Post('create')
   async createMachine(@Body() createMachineDTO: CreateMachineDTO) {
-    await this.orchestrationService.createMachine(createMachineDTO.name);
-    return `Machine ${createMachineDTO.name} successfuly created`;
+    try {
+      await this.orchestrationService.createMachine(createMachineDTO.name);
+      return `Machine ${createMachineDTO.name} successfuly created`;
+    } catch (error) {
+      return `Error while creating the machine`
+    }
   }
 }

--- a/libs/api-implementation/orchestration/src/lib/services/orchestration.service.ts
+++ b/libs/api-implementation/orchestration/src/lib/services/orchestration.service.ts
@@ -34,6 +34,7 @@ export class VMOrchestrationService implements VMOrchestrationInterface {
     } catch (error) {
       console.error("Error while machine creation:")
       console.debug(error.stack)
+      throw(error)
     }
   }
 
@@ -53,7 +54,7 @@ export class VMOrchestrationService implements VMOrchestrationInterface {
     );
 
     return {
-      os: 'ubuntu',
+      os: 'ubuntu-1804',
       http: true,
       metadata: {
         items: [
@@ -73,6 +74,7 @@ export class VMOrchestrationService implements VMOrchestrationInterface {
     } catch (error) {
       console.error(`Error occured while reseting the machine ${name}`)
       console.debug(error.stack)
+      throw(error)
     }
   }
 
@@ -83,6 +85,7 @@ export class VMOrchestrationService implements VMOrchestrationInterface {
     } catch (error) {
       console.error(`Error occured while starting the machine ${name}`)
       console.debug(error.stack)
+      throw(error)
     }
   }
 
@@ -98,6 +101,7 @@ export class VMOrchestrationService implements VMOrchestrationInterface {
     } catch (error) {
       console.error(`Error occured while stopping machine`);
       console.debug(error.stack)
+      throw(error)
     }
   }
 
@@ -114,6 +118,7 @@ export class VMOrchestrationService implements VMOrchestrationInterface {
     } catch (error) {
       console.error(`Error occured while deleting the machine ${name}`);
       console.debug(error.stack)
+      throw(error)
     }
   }
   

--- a/libs/github-interactions-api/tsconfig.json
+++ b/libs/github-interactions-api/tsconfig.json
@@ -4,5 +4,5 @@
     "types": ["node", "jest"],
     "target": "es6"
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "../../config.ts"]
 }

--- a/script.sh
+++ b/script.sh
@@ -26,9 +26,9 @@ config=`curl -f http://metadata.google.internal/computeMetadata/v1/project/attri
 # write it to file
 echo $config > $config_file
 
-
 cd ~
 
+# bucket mounting
 echo "deb http://packages.cloud.google.com/apt gcsfuse-bionic main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
@@ -44,4 +44,29 @@ sudo usermod -a -G fuse $USER
 mkdir bucket
 GOOGLE_APPLICATION_CREDENTIALS=/opt/g-credentials.json gcsfuse ccextractor-samples bucket
 
+# installation of mono and tesseract
+sudo apt install gnupg ca-certificates
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb http://download.mono-project.com/repo/ubuntu wheezy/snapshots/4.8.0 main" | sudo tee /etc/apt/sources.list.d/mono-official.list
+sudo apt update
+
+# this is specific solution for the Ubuntu version, since the official dependencies doesn't work.
+apt-get install -y mono-devel
+apt install -y tesseract-ocr
+
+# run tests
+sudo ldconfig
+
+cp /root/bucket/ccextractor /root/
+cp -R /root/bucket/tester /root/
+
+sudo chmod +x ccextractor
+sudo chmod +x tester/ccextractortester
+
+mkdir tmpFolder
+mkdir results
+mkdir report
+
+cd /root/tester
+sudo /root/tester/ccextractortester --entries "/root/bucket/tests.xml" --executable "/root/ccextractor" --tempfolder "/root/tmpFiles" --timeout 3000 --resultfolder "/root/results" --samplefolder "/root/bucket/samples" --reportfolder "/root/report"
 


### PR DESCRIPTION
**Problem:**

Even though on #8 the child machine will mount the bucket, it couldn't execute the ccx_testsuite. I've uploaded some samples to the bucket, so it can execute it. Also in this PR, added the creation of the proper folder structure inside of the child machine, permissions, installation of a mono, tesseract, and more. 

**Key features**:
- Now on the request to create a machine, the machine will startup, install go, dependencies, mount the bucket, take samples, and execute it. 
- Except that, in this PR I've Incapsulated the error in service and send the generic error message to the client. I think this is a better practice than sending one message independently whether there is an error or not.